### PR TITLE
通信データのフォーマット変更

### DIFF
--- a/RasPi/main/irrp_wrapper.py
+++ b/RasPi/main/irrp_wrapper.py
@@ -5,20 +5,37 @@ import os
 import sys
 import subprocess
 
-#エアコン制御用のリクエスト
-request_list = [
-  "dumy",
-  "python ./../lib/irrp.py -p -g4 -f ./../lib/signal ON",
-  "python ./../lib/irrp.py -p -g4 -f ./../lib/signal OFF",
-  "UP",
-  "DOWN",
+
+devise_requests = [
+  {
+    #devise_id:1
+    ##エアコン制御用のリクエスト
+    "ON": "python ./../lib/irrp.py -p -g4 -f ./../lib/signal ON",
+    "OFF": "python ./../lib/irrp.py -p -g4 -f ./../lib/signal OFF",
+    "UP": "sl",
+    "DOWN": "sl",
+    "STATUS": "sl",
+  }
 ]
 
-def request(id):
+def request(devise_id, request_code):
   global request_list
-  cmd = request_list[id]
+  ret = 1
+
+  _id = devise_id - 1
+  if _id <0 or _id >= len(devise_requests):
+    print("devise_id判別エラー")
+    return 1
+
+  cmd = devise_requests[_id].get(request_code)
+  if cmd is None:
+    print("サポートされていないリクエスト")
+    return 1
+
   print(cmd)
   subprocess.Popen(cmd.split())
+  return 0
+
 
 if __name__ == "__main__":
   request(int(sys.argv[1]))


### PR DESCRIPTION

現状では、AWS→RasPiへ送るデータを"AABB"の数字データを桁で区切る形式となっている。
これだと、ぱっと見で分かりづらい上に、RasPi内部で無駄な変換処理を行っている。
よって、JSON形式に統一し可読性UPと、変換処理をなくす事による効率化を図る。

